### PR TITLE
Refactor: Make Config.toml required, API key resolution unchanged

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -19,7 +19,12 @@ dns = { enabled = false, port = 53 }
 sms = { enabled = false, port = 5000 }
 
 [chatgpt]
-api_key = "chatgpt-api-key"
+# The API key for ChatGPT.
+# This is optional if the CHATGPT_API_KEY environment variable is set.
+# api_key = "your-chatgpt-api-key"
+#
+# Static messages are required for ChatGPT interaction.
+static_messages = { message1 = "You are an Ubuntu Server.", message2 = "Respond as an Ubuntu server would. Do not break character." }
 
 [registration]
 rustbucket_registry_url = "http://localhost:8080/register"


### PR DESCRIPTION
This commit refactors the ChatGPT configuration loading:
- `Config.toml` is now required for the application to start. If the file is missing, an error will occur.
- The logic for resolving the ChatGPT API key remains the same:
    1. Environment variable `CHATGPT_API_KEY`.
    2. `api_key` field in `Config.toml` under the `[chatgpt]` section.
    3. If neither is found, an error is returned, causing startup failure.
- The `static_messages` field under `[chatgpt]` in `Config.toml` remains mandatory.

This change clarifies that while the API key itself has flexible sourcing, the main configuration file housing other essential settings like `static_messages` is not optional. This supersedes the previous commit where the entire file was inadvertently made optional.