### PR TITLE
Add centralized S3 config from registry

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,6 @@ use protocols::http::HttpHandler;
 use protocols::ftp::FtpHandler;
 use protocols::smtp::SmtpHandler;
 use s3_logger::S3Logger;
-use rand::distributions::Alphanumeric;
-use rand::Rng;
 
 
 
@@ -94,12 +92,14 @@ async fn main() -> tokio::io::Result<()> {
         .init();
     info!("Tracing initialized");
 
-    // Generate instance name for this Rustbucket
-    let instance_name = generate_instance_name();
-    info!("Instance name: {}", instance_name);
+    // Register this instance first to get S3 config from registry.
+    // Identity is persisted in .rustbucket_identity so the same name/token
+    // and S3 config are used across restarts.
+    let identity = registration::register_instance().await;
+    info!("Instance name: {}", identity.name);
 
-    // Initialize S3 logger
-    match S3Logger::new(instance_name.clone()).await {
+    // Initialize S3 logger with config from registration (or fallback to env/config)
+    match S3Logger::new_with_identity(identity.clone()).await {
         Ok(s3_logger) => {
             if s3_logger.is_enabled() {
                 info!("S3 logging is enabled");
@@ -112,11 +112,6 @@ async fn main() -> tokio::io::Result<()> {
             error!("Failed to initialize S3 logger: {}. Continuing without S3 logging.", e);
         }
     }
-
-    // Register this instance (optional).
-    // Identity is persisted in .rustbucket_identity so the same name/token
-    // is used across restarts.
-    registration::register_instance().await;
 
     // Create tasks for each listener on different ports
     let ports = vec!["0.0.0.0:22", "0.0.0.0:25", "0.0.0.0:21", "0.0.0.0:80"];
@@ -142,14 +137,4 @@ async fn main() -> tokio::io::Result<()> {
     // This point should never be reached unless all listeners fail
     error!("All listeners have stopped. This should not happen.");
     Ok(())
-}
-
-/// Generate a unique instance name for this Rustbucket
-fn generate_instance_name() -> String {
-    let random_suffix: String = rand::thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(8)
-        .map(char::from)
-        .collect();
-    format!("rustbucket-{}", random_suffix)
 }

--- a/src/registration.rs
+++ b/src/registration.rs
@@ -24,9 +24,15 @@ struct AppConfig {
 
 /// Persistent identity for this rustbucket instance
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct InstanceIdentity {
-    name: String,
-    token: String,
+pub struct InstanceIdentity {
+    pub name: String,
+    pub token: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub s3_bucket: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub s3_region: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub s3_prefix: Option<String>,
 }
 
 /// System information collected for registration
@@ -39,6 +45,22 @@ struct SystemInfo {
     disk_space: Option<String>,
     uptime: Option<String>,
     connections: Option<String>,
+}
+
+/// S3 configuration returned by the registry
+#[derive(Debug, Clone, Deserialize)]
+struct S3ConfigResponse {
+    s3_bucket: String,
+    s3_region: String,
+    s3_prefix: String,
+}
+
+/// Registration response from the registry
+#[derive(Debug, Clone, Deserialize)]
+struct RegistrationResponse {
+    status: String,
+    #[serde(default)]
+    s3_config: Option<S3ConfigResponse>,
 }
 
 #[derive(Serialize, Clone, Debug)]
@@ -106,12 +128,13 @@ async fn collect_system_info() -> SystemInfo {
 }
 
 /// Send registration request to the registry
+/// Returns S3 config if provided in the response
 async fn send_registration_request(
     registry_url: &str,
     name: &str,
     token: &str,
     system_info: &SystemInfo,
-) -> bool {
+) -> Option<S3ConfigResponse> {
     let payload = RegistrationPayload {
         name: name.to_string(),
         ip_address: system_info.ip_address.clone(),
@@ -150,22 +173,38 @@ async fn send_registration_request(
             match status {
                 reqwest::StatusCode::OK => {
                     info!("Successfully registered instance '{}'. Server response: {}", name, response_text);
-                    true
+
+                    // Parse response to extract S3 config
+                    match serde_json::from_str::<RegistrationResponse>(&response_text) {
+                        Ok(reg_response) => {
+                            if let Some(ref s3_config) = reg_response.s3_config {
+                                info!(
+                                    "Received S3 config from registry: bucket={}, region={}, prefix={}",
+                                    s3_config.s3_bucket, s3_config.s3_region, s3_config.s3_prefix
+                                );
+                            }
+                            reg_response.s3_config
+                        }
+                        Err(e) => {
+                            warn!("Failed to parse registration response: {}. S3 config not available.", e);
+                            None
+                        }
+                    }
                 }
                 reqwest::StatusCode::NOT_FOUND => {
                     error!("Registration failed: Bad URL (404 Not Found) for {}. Server response: {}", normalized_url, response_text);
-                    false
+                    None
                 }
                 reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
                     error!("Registration failed: Server error (500) at {}. Server response: {}", normalized_url, response_text);
-                    false
+                    None
                 }
                 _ => {
                     warn!(
                         "Registration attempt to {} returned unexpected status: {}. Server response: {}",
                         normalized_url, status, response_text
                     );
-                    false
+                    None
                 }
             }
         }
@@ -176,7 +215,7 @@ async fn send_registration_request(
             if let Some(url_err) = e.url() {
                 error!("URL that caused the error: {}", url_err);
             }
-            false
+            None
         }
     }
 }
@@ -221,6 +260,9 @@ fn load_or_create_identity() -> InstanceIdentity {
     let identity = InstanceIdentity {
         name: generate_name(),
         token: generate_token(),
+        s3_bucket: None,
+        s3_region: None,
+        s3_prefix: None,
     };
 
     // Save to file for next restart
@@ -244,37 +286,72 @@ fn load_or_create_identity() -> InstanceIdentity {
     identity
 }
 
-pub async fn register_instance() {
+/// Save identity to file
+fn save_identity(identity: &InstanceIdentity) {
+    let identity_path = Path::new(IDENTITY_FILE);
+    match serde_json::to_string_pretty(identity) {
+        Ok(json) => {
+            if let Err(e) = fs::write(identity_path, json) {
+                warn!("Failed to save identity file: {}", e);
+            } else {
+                info!(
+                    name = %identity.name,
+                    "Saved instance identity to {}",
+                    IDENTITY_FILE
+                );
+            }
+        }
+        Err(e) => {
+            warn!("Failed to serialize identity: {}", e);
+        }
+    }
+}
+
+/// Register instance and return identity with S3 config if available
+pub async fn register_instance() -> InstanceIdentity {
     info!("Checking registration configuration...");
+
+    // Load or create persistent identity (survives restarts)
+    let mut identity = load_or_create_identity();
+    info!(
+        name = %identity.name,
+        "Using instance identity"
+    );
 
     // Load registry URL
     let registry_url = match load_registration_url() {
         Some(url) => url,
         None => {
             info!("No registry URL configured. Skipping registration.");
-            return;
+            return identity;
         }
     };
-
-    // Load or create persistent identity (survives restarts)
-    let identity = load_or_create_identity();
-    info!(
-        name = %identity.name,
-        "Using instance identity"
-    );
 
     // Collect system information
     let system_info = collect_system_info().await;
 
     // Attempt registration
     info!("Attempting to register instance with URL: {}", registry_url);
-    send_registration_request(
+    let s3_config = send_registration_request(
         &registry_url,
         &identity.name,
         &identity.token,
         &system_info,
     )
     .await;
+
+    // Update identity with S3 config if received from registry
+    if let Some(config) = s3_config {
+        identity.s3_bucket = Some(config.s3_bucket);
+        identity.s3_region = Some(config.s3_region);
+        identity.s3_prefix = Some(config.s3_prefix);
+
+        // Save updated identity to file
+        save_identity(&identity);
+        info!("Updated identity with S3 configuration from registry");
+    }
+
+    identity
 }
 
 fn generate_name() -> String {
@@ -424,11 +501,16 @@ mod tests {
         let identity = InstanceIdentity {
             name: "rustbucket-test1234".to_string(),
             token: "abcdef1234567890abcdef1234567890".to_string(),
+            s3_bucket: None,
+            s3_region: None,
+            s3_prefix: None,
         };
 
         let json = serde_json::to_string(&identity).unwrap();
         assert!(json.contains("rustbucket-test1234"));
         assert!(json.contains("abcdef1234567890abcdef1234567890"));
+        // S3 fields should be omitted when None
+        assert!(!json.contains("s3_bucket"));
 
         let parsed: InstanceIdentity = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.name, identity.name);
@@ -436,11 +518,60 @@ mod tests {
     }
 
     #[test]
+    fn test_instance_identity_with_s3_config() {
+        let identity = InstanceIdentity {
+            name: "rustbucket-test1234".to_string(),
+            token: "abcdef1234567890abcdef1234567890".to_string(),
+            s3_bucket: Some("my-bucket".to_string()),
+            s3_region: Some("us-west-2".to_string()),
+            s3_prefix: Some("logs/rustbucket-test1234/".to_string()),
+        };
+
+        let json = serde_json::to_string(&identity).unwrap();
+        assert!(json.contains("my-bucket"));
+        assert!(json.contains("us-west-2"));
+        assert!(json.contains("logs/rustbucket-test1234/"));
+
+        let parsed: InstanceIdentity = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.s3_bucket, Some("my-bucket".to_string()));
+        assert_eq!(parsed.s3_region, Some("us-west-2".to_string()));
+        assert_eq!(parsed.s3_prefix, Some("logs/rustbucket-test1234/".to_string()));
+    }
+
+    #[test]
     fn test_instance_identity_deserialization() {
+        // Test backward compatibility - old format without S3 fields
         let json = r#"{"name":"rustbucket-abcd1234","token":"token123456789012345678901234"}"#;
         let identity: InstanceIdentity = serde_json::from_str(json).unwrap();
 
         assert_eq!(identity.name, "rustbucket-abcd1234");
         assert_eq!(identity.token, "token123456789012345678901234");
+        assert_eq!(identity.s3_bucket, None);
+        assert_eq!(identity.s3_region, None);
+        assert_eq!(identity.s3_prefix, None);
+    }
+
+    #[test]
+    fn test_registration_response_parsing() {
+        // Test parsing response with S3 config
+        let json = r#"{"status":"success","s3_config":{"s3_bucket":"honeypot-logs","s3_region":"us-east-1","s3_prefix":"logs/rustbucket-test/"}}"#;
+        let response: RegistrationResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(response.status, "success");
+        assert!(response.s3_config.is_some());
+        let s3_config = response.s3_config.unwrap();
+        assert_eq!(s3_config.s3_bucket, "honeypot-logs");
+        assert_eq!(s3_config.s3_region, "us-east-1");
+        assert_eq!(s3_config.s3_prefix, "logs/rustbucket-test/");
+    }
+
+    #[test]
+    fn test_registration_response_without_s3() {
+        // Test parsing response without S3 config (backward compatibility)
+        let json = r#"{"status":"success"}"#;
+        let response: RegistrationResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(response.status, "success");
+        assert!(response.s3_config.is_none());
     }
 }

--- a/src/s3_logger.rs
+++ b/src/s3_logger.rs
@@ -8,6 +8,8 @@ use std::time::{Duration, SystemTime};
 use tokio::time::sleep;
 use tracing::{info, error, warn};
 
+use crate::registration::InstanceIdentity;
+
 /// S3 logging configuration
 #[derive(Debug, Clone, Deserialize)]
 pub struct S3Config {
@@ -92,6 +94,72 @@ impl S3Logger {
             config,
             client,
             instance_name,
+            log_directory,
+        })
+    }
+
+    /// Create a new S3Logger instance using identity from registration
+    /// This prioritizes S3 config from the registry over local config
+    pub async fn new_with_identity(identity: InstanceIdentity) -> Result<Self, String> {
+        // Load base configuration from file
+        let settings = Config::builder()
+            .add_source(File::with_name("Config").required(false))
+            .build()
+            .map_err(|e| e.to_string())?;
+
+        let mut config: S3Config = settings
+            .get("s3_logging")
+            .unwrap_or_else(|_| S3Config::default());
+
+        // Priority: Registry config > Environment variables > Config file
+        // Check if identity has S3 config from registry
+        if let Some(bucket) = &identity.s3_bucket {
+            info!("Using S3 bucket from registry: {}", bucket);
+            config.bucket_name = Some(bucket.clone());
+            config.enabled = true;  // Enable if registry provides config
+        } else if let Ok(bucket) = std::env::var("S3_BUCKET_NAME") {
+            config.bucket_name = Some(bucket);
+        }
+
+        if let Some(region) = &identity.s3_region {
+            info!("Using S3 region from registry: {}", region);
+            config.region = Some(region.clone());
+        } else if let Ok(region) = std::env::var("S3_REGION") {
+            config.region = Some(region);
+        }
+
+        if let Some(prefix) = &identity.s3_prefix {
+            info!("Using S3 prefix from registry: {}", prefix);
+            config.prefix = Some(prefix.clone());
+        } else if let Ok(prefix) = std::env::var("S3_PREFIX") {
+            config.prefix = Some(prefix);
+        }
+
+        // Still allow environment variables to override enabled flag
+        if let Ok(enabled) = std::env::var("S3_LOGGING_ENABLED") {
+            config.enabled = enabled.to_lowercase() == "true";
+        }
+
+        if let Ok(delete) = std::env::var("S3_DELETE_AFTER_UPLOAD") {
+            config.delete_after_upload = delete.to_lowercase() == "true";
+        }
+
+        // Get log directory from config or use default
+        let log_directory = settings
+            .get_string("general.log_directory")
+            .unwrap_or_else(|_| "./logs".to_string());
+
+        // Initialize S3 client if enabled
+        let client = if config.enabled {
+            Some(Self::create_s3_client(&config).await?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            config,
+            client,
+            instance_name: identity.name,
             log_directory,
         })
     }


### PR DESCRIPTION
- Registry now returns S3 bucket/region/prefix in registration response
- Rustbucket parses response and persists S3 config in identity file
- S3Logger prioritizes registry config over local env/config
- Registration happens before S3Logger init to receive config
- Added tests for new S3 config parsing and serialization